### PR TITLE
Make terminal-panel useable on Ubuntu 14.04

### DIFF
--- a/keymaps/cli-status.cson
+++ b/keymaps/cli-status.cson
@@ -7,14 +7,14 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.platform-darwin .workspace':
+'.platform-darwin atom-workspace':
   'shift-enter': 'terminal-panel:toggle'
   'cmd-shift-t': 'terminal-panel:new'
   'cmd-shift-j': 'terminal-panel:next'
   'cmd-shift-k': 'terminal-panel:prev'
   'cmd-shift-x': 'terminal-panel:destroy'
 
-'.platform-linux .workspace, .platform-win32 .workspace':
+'.platform-linux atom-workspace, .platform-win32 atom-workspace':
   'shift-enter': 'terminal-panel:toggle'
   'alt-shift-t': 'terminal-panel:new'
   'alt-shift-j': 'terminal-panel:next'

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -29,8 +29,6 @@ class CommandOutputView extends View
         @subview 'cmdEditor', new TextEditorView(mini: true, placeholderText: 'input your command here')
 
   initialize: ->
-    @subscribe atom.config.observe 'terminal-panel.WindowHeight', => @adjustWindowHeight()
-
     @userHome = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE
     cmd = 'test -e /etc/profile && source /etc/profile;test -e ~/.profile && source ~/.profile; node -pe "JSON.stringify(process.env)"'
     exec cmd, (code, stdout, stderr) ->


### PR DESCRIPTION
fixes #24 and a minor deprecation warning, recommend bumping version to 1.9.1