### PR TITLE
Keyboard Shortcut Updates

### DIFF
--- a/keymaps/cli-status.cson
+++ b/keymaps/cli-status.cson
@@ -8,14 +8,14 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.platform-darwin atom-workspace':
-  'shift-enter': 'terminal-panel:toggle'
+  'ctrl-shift-enter': 'terminal-panel:toggle'
   'cmd-shift-t': 'terminal-panel:new'
   'cmd-shift-j': 'terminal-panel:next'
   'cmd-shift-k': 'terminal-panel:prev'
   'cmd-shift-x': 'terminal-panel:destroy'
 
 '.platform-linux atom-workspace, .platform-win32 atom-workspace':
-  'shift-enter': 'terminal-panel:toggle'
+  'ctrl-shift-enter': 'terminal-panel:toggle'
   'alt-shift-t': 'terminal-panel:new'
   'alt-shift-j': 'terminal-panel:next'
   'alt-shift-k': 'terminal-panel:prev'


### PR DESCRIPTION
- The keyboard shortcut of ```shift+enter``` was already being used.
- Changed keyboard shortcut to ```control+shift+enter```