### PR TITLE
Make it a bit more pretty

### DIFF
--- a/stylesheets/cli-status.less
+++ b/stylesheets/cli-status.less
@@ -7,9 +7,10 @@
 .cli-status {
   &.panel {
     margin-bottom: 0px;
+  }
+  .cli-panel-body {
     white-space: pre;
     word-wrap: break-word;
-    font-size: 14px;
     font-family: monospace;
   }
   .panel-heading {
@@ -18,6 +19,18 @@
     text-align: right;
     .btn {
       top: 0px;
+      height: auto;
+    }
+    .hide + .btn:not(:first-child):not(:last-child):not(.dropdown-toggle) {
+      border-top-left-radius: @component-border-radius;
+      border-bottom-left-radius: @component-border-radius;
+    }
+    .icon {
+      display: inline-block;
+      &::before {
+        position: relative;
+        top: 1px;
+      }
     }
   }
   .terminal {


### PR DESCRIPTION
- the font size for editor.mini is set in `em`, so setting `14px` on the `.cli-panel-body` makes the input huge
- the first button in the button group isn't rounded because there is hidden button before it (blame Bootstrap for the hideous selector)
- buttons are in monospace which isn't all that pretty
- there is both a height and a line-height on the buttons, which in combination with the border makes the text sit off-center
- the x-icon sits off-center

after
![before](https://cloud.githubusercontent.com/assets/2543659/7300277/987347c4-e9db-11e4-8797-738aa9a41e7f.png)

before
![after](https://cloud.githubusercontent.com/assets/2543659/7300276/9850421a-e9db-11e4-8127-45f19dba5e97.png)


PS. I'm seeing [guileen/terminal-status](/guileen/terminal-status) getting some traction again with a new maintainer. Any idea how different this fork is?