### PR TITLE
Mimic command history up and down keys

### DIFF
--- a/keymaps/cli-status.cson
+++ b/keymaps/cli-status.cson
@@ -24,3 +24,7 @@
 '.cli-status':
   'cmd-c': 'native!'
   'ctrl-c': 'native!'
+  
+'.cli-status atom-text-editor':
+  'up': 'core:undo'
+  'down': 'core:redo'


### PR DESCRIPTION
Binds <kbd>Up</kbd> and <kbd>Down</kbd> keys to `core:undo` and `core:redo`, respectively, as those keys are quite common for command history.