### PR TITLE
Replace .buttons class with .btn-group

### DIFF
--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -17,7 +17,7 @@ class CommandOutputView extends View
         @pre class: "terminal", outlet: "cliOutput"
       @div class: 'cli-panel-input', =>
         @subview 'cmdEditor', new TextEditorView(mini: true, placeholderText: 'input your command here')
-        @div class: 'btn-group buttons', =>
+        @div class: 'btn-group', =>
           @button outlet: 'killBtn', click: 'kill', class: 'btn hide', =>
             @span 'kill'
           @button click: 'destroy', class: 'btn', =>

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -18,10 +18,8 @@ class CommandOutputView extends View
       @div class: 'cli-panel-input', =>
         @subview 'cmdEditor', new TextEditorView(mini: true, placeholderText: 'input your command here')
         @div class: 'btn-group', =>
-          @button outlet: 'killBtn', click: 'kill', class: 'btn hide', =>
-            @span 'kill'
-          @button click: 'destroy', class: 'btn', =>
-            @span 'destroy'
+          @button outlet: 'killBtn', click: 'kill', class: 'btn hide', 'kill'
+          @button click: 'destroy', class: 'btn', destroy'
           @span class: 'icon icon-x', click: 'close'
 
   initialize: ->

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -19,7 +19,7 @@ class CommandOutputView extends View
         @subview 'cmdEditor', new TextEditorView(mini: true, placeholderText: 'input your command here')
         @div class: 'btn-group', =>
           @button outlet: 'killBtn', click: 'kill', class: 'btn hide', 'kill'
-          @button click: 'destroy', class: 'btn', destroy'
+          @button click: 'destroy', class: 'btn', 'destroy'
           @span class: 'icon icon-x', click: 'close'
 
   initialize: ->

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -17,7 +17,7 @@ class CommandOutputView extends View
         @pre class: "terminal", outlet: "cliOutput"
       @div class: 'cli-panel-input', =>
         @subview 'cmdEditor', new TextEditorView(mini: true, placeholderText: 'input your command here')
-        @div class: 'buttons', =>
+        @div class: 'btn-group buttons', =>
           @button outlet: 'killBtn', click: 'kill', class: 'btn hide', =>
             @span 'kill'
           @button click: 'destroy', class: 'btn', =>

--- a/styles/cli-status.less
+++ b/styles/cli-status.less
@@ -32,8 +32,21 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
+
     > * {
       margin-left: @component-padding;
+    }
+
+    .btn:first-of-type:not(:last-of-type) {
+      border-radius: @component-border-radius 0 0 @component-border-radius;
+    }
+
+    .btn:last-of-type:not(:first-of-type) {
+      border-radius: 0 @component-border-radius @component-border-radius 0;
+    }
+
+    .hide + .btn:last-of-type {
+      border-radius: @component-border-radius
     }
   }
   .terminal {

--- a/styles/cli-status.less
+++ b/styles/cli-status.less
@@ -28,7 +28,7 @@
   .panel-heading {
     display: none;
   }
-  .buttons {
+  .btn-group {
     display: flex;
     align-items: center;
     justify-content: flex-end;


### PR DESCRIPTION
Keeps the styling in line with the find-and-replace panel. Tested with the default themes and a few others.

Before:
![terminal-panel-before](https://cloud.githubusercontent.com/assets/3612514/7517943/49b37be2-f4d8-11e4-96e3-314867b3a63e.png)

After:
![terminal-panel-after](https://cloud.githubusercontent.com/assets/3612514/7517944/4c5dd842-f4d8-11e4-8462-36fe2f6faf6d.png)

Note the space between the buttons and the atom-text-editor