### PR TITLE
Configurable height

### DIFF
--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -20,9 +20,9 @@ module.exports =
   #   cliStatusViewState: @cliStatusView.serialize()
 
   config:
-    'WindowHeight':
+    'windowHeight':
       type: 'integer'
-      default: 300
+      default: 30
     'clearCommandInput':
       type: 'boolean'
       default: true

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -55,10 +55,6 @@ class CommandOutputView extends View
         return @cmdEditor.setText ''
       @spawn inputCmd, cmd, args
 
-  adjustWindowHeight: ->
-    maxHeight = atom.config.get('terminal-panel.WindowHeight')
-    @cliOutput.css("max-height", "#{maxHeight}px")
-
   showCmd: ->
     @cmdEditor.show()
     @cmdEditor.getModel().selectAll()
@@ -104,6 +100,12 @@ class CommandOutputView extends View
     @cmdEditor.focus()
     @cliOutput.css('font-family', atom.config.get('editor.fontFamily'))
     @cliOutput.css('font-size', atom.config.get('editor.fontSize') + 'px')
+    console.log atom.config.get('terminal-panel.windowHeight')
+    if atom.config.get('terminal-panel.windowHeight') > 80
+      maxHeight = 80
+    else
+      maxHeight = atom.config.get('terminal-panel.windowHeight')
+    @cliOutput.css('max-height', maxHeight +' vh')
 
   close: ->
     @lastLocation.activate()

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -102,10 +102,10 @@ class CommandOutputView extends View
     @cliOutput.css('font-size', atom.config.get('editor.fontSize') + 'px')
     console.log atom.config.get('terminal-panel.windowHeight')
     if atom.config.get('terminal-panel.windowHeight') > 80
-      maxHeight = 80
+      maxHeight = 80 + 'vh'
     else
-      maxHeight = atom.config.get('terminal-panel.windowHeight')
-    @cliOutput.css('max-height', maxHeight +' vh')
+      maxHeight = atom.config.get('terminal-panel.windowHeight') + 'vh'
+    @cliOutput.css('max-height', maxHeight)
 
   close: ->
     @lastLocation.activate()

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -57,6 +57,7 @@ class CommandOutputView extends View
 
   showCmd: ->
     @cmdEditor.show()
+    @cmdEditor.css('visibility', '')
     @cmdEditor.getModel().selectAll()
     @cmdEditor.setText('') if atom.config.get('terminal-panel.clearCommandInput')
     @cmdEditor.focus()
@@ -217,7 +218,7 @@ class CommandOutputView extends View
     @cwd or projectDir or @userHome
 
   spawn: (inputCmd, cmd, args) ->
-    @cmdEditor.hide()
+    @cmdEditor.css('visibility', 'hidden')
     htmlStream = ansihtml()
     htmlStream.on 'data', (data) =>
       @cliOutput.append data

--- a/styles/cli-status.less
+++ b/styles/cli-status.less
@@ -37,8 +37,7 @@
     }
   }
   .terminal {
-    // let's keep this as a fallback
-    max-height: 300px;
+    max-height: 30vh;
     overflow-y: scroll;
     bottom: @component-padding;
     border-radius: 0;


### PR DESCRIPTION
Make height config work and make it a percentage of the viewport height.
Break compatibility with previous (non-working) config value which would be 10x too high to work.
Guard against values that are too large (ie. it won't fit the viewport).
