### PR TITLE
Set min and max values for windowHeight in config

### DIFF
--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -23,6 +23,8 @@ module.exports =
     'windowHeight':
       type: 'integer'
       default: 30
+      minimum: 0
+      maximum: 80
     'clearCommandInput':
       type: 'boolean'
       default: true

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -101,8 +101,7 @@ class CommandOutputView extends View
     @cmdEditor.focus()
     @cliOutput.css('font-family', atom.config.get('editor.fontFamily'))
     @cliOutput.css('font-size', atom.config.get('editor.fontSize') + 'px')
-    maxHeight = atom.config.get('terminal-panel.windowHeight')
-    @cliOutput.css('max-height', maxHeight + 'vh')
+    @cliOutput.css('max-height', atom.config.get('terminal-panel.windowHeight') + 'vh')
 
   close: ->
     @lastLocation.activate()

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -101,12 +101,8 @@ class CommandOutputView extends View
     @cmdEditor.focus()
     @cliOutput.css('font-family', atom.config.get('editor.fontFamily'))
     @cliOutput.css('font-size', atom.config.get('editor.fontSize') + 'px')
-    console.log atom.config.get('terminal-panel.windowHeight')
-    if atom.config.get('terminal-panel.windowHeight') > 80
-      maxHeight = 80 + 'vh'
-    else
-      maxHeight = atom.config.get('terminal-panel.windowHeight') + 'vh'
-    @cliOutput.css('max-height', maxHeight)
+    maxHeight = atom.config.get('terminal-panel.windowHeight')
+    @cliOutput.css('max-height', maxHeight + 'vh')
 
   close: ->
     @lastLocation.activate()


### PR DESCRIPTION
Config type `integer` can have a `minimum` and `maximum` property to limit the value of the setting. You can use those instead of checking for out of range values yourself.