### PR TITLE
Startup performance

### DIFF
--- a/lib/cli-status-view.coffee
+++ b/lib/cli-status-view.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable} = require 'atom'
 {View} = require 'atom-space-pen-views'
 
 module.exports =
@@ -5,10 +6,12 @@ class CliStatusView extends View
   @content: ->
     @div class: 'cli-status inline-block', =>
       @span outlet: 'termStatusContainer', =>
-        @span click: 'newTermClick', class: "cli-status icon icon-plus"
+        @span click: 'newTermClick', outlet: 'termStatusAdd', class: "cli-status icon icon-plus"
 
   commandViews: []
   activeIndex: 0
+  toolTipDisposable: null
+
   initialize: (serializeState) ->
     atom.commands.add 'atom-workspace',
       'terminal-panel:new': => @newTermClick()
@@ -21,6 +24,8 @@ class CliStatusView extends View
       'core:cancel': => @toggle()
 
     @attach()
+    @toolTipDisposable?.dispose()
+    @toolTipDisposable = atom.tooltips.add @termStatusAdd, title: "Add a terminal panel"
 
   createCommandView: ->
     domify = require 'domify'

--- a/lib/cli-status-view.coffee
+++ b/lib/cli-status-view.coffee
@@ -1,6 +1,4 @@
 {View} = require 'atom-space-pen-views'
-domify = require 'domify'
-CommandOutputView = require './command-output-view'
 
 module.exports =
 class CliStatusView extends View
@@ -18,14 +16,15 @@ class CliStatusView extends View
       'terminal-panel:next': => @activeNextCommandView()
       'terminal-panel:prev': => @activePrevCommandView()
       'terminal-panel:destroy': => @destroyActiveTerm()
-      
+
     atom.commands.add '.cli-status',
       'core:cancel': => @toggle()
 
-    @createCommandView()
     @attach()
 
   createCommandView: ->
+    domify = require 'domify'
+    CommandOutputView = require './command-output-view'
     termStatus = domify '<span class="cli-status icon icon-terminal"></span>'
     commandOutputView = new CommandOutputView
     commandOutputView.statusIcon = termStatus

--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -1,17 +1,13 @@
-CliStatusView = require './cli-status-view'
 
 module.exports =
   cliStatusView: null
 
   activate: (state) ->
-    createStatusEntry = =>
-      @cliStatusView = new CliStatusView(state.cliStatusViewState)
-
-    if atom.views.getView(atom.workspace).statusBar
+    atom.packages.onDidActivateInitialPackages ->
+      CliStatusView = require './cli-status-view'
+      createStatusEntry = =>
+        @cliStatusView = new CliStatusView(state.cliStatusViewState)
       createStatusEntry()
-    else
-      atom.packages.onDidActivateInitialPackages ->
-        createStatusEntry()
 
   deactivate: ->
     @cliStatusView.destroy()

--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -1,9 +1,8 @@
-
 module.exports =
   cliStatusView: null
 
   activate: (state) ->
-    atom.packages.onDidActivateInitialPackages ->
+    atom.packages.onDidActivateInitialPackages =>
       CliStatusView = require './cli-status-view'
       createStatusEntry = =>
         @cliStatusView = new CliStatusView(state.cliStatusViewState)


### PR DESCRIPTION
Fixes #4 

- don't create an output view at startup (you can create one when you need one)
- postpone requires until they are used in a method
- great success:
![screen shot 2015-05-11 at 19 42 14](https://cloud.githubusercontent.com/assets/2543659/7571188/236937ce-f816-11e4-8141-fdff70643edb.png)

I discovered that the package doesn't properly remove open terminal-panels on deactivate, but that's not a regression. Will open up a different issue for that. 

@thedaniel @zephraph any further opinions?