### PR TITLE
Add shell config

### DIFF
--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -29,4 +29,7 @@ module.exports =
       default: true
     'shell':
       type: 'string'
-      default: process.env.SHELL # TODO: add some windows variant
+      default: if process.platform is 'win32'
+        'cmd.exe'
+      else
+        process.env.SHELL ? '/bin/bash'

--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -30,6 +30,6 @@ module.exports =
     'shell':
       type: 'string'
       default: if process.platform is 'win32'
-        'cmd.exe'
-      else
-        process.env.SHELL ? '/bin/bash'
+          'cmd.exe'
+        else
+          process.env.SHELL ? '/bin/bash'

--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -27,3 +27,6 @@ module.exports =
       title: 'Override ls'
       type: 'boolean'
       default: true
+    'shell':
+      type: 'string'
+      default: process.env.SHELL # TODO: add some windows variant

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -25,7 +25,8 @@ class CommandOutputView extends View
   initialize: ->
     @userHome = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE
     cmd = 'test -e /etc/profile && source /etc/profile;test -e ~/.profile && source ~/.profile; node -pe "JSON.stringify(process.env)"'
-    exec cmd, (code, stdout, stderr) ->
+    shell = atom.config.get 'terminal-panel.shell'
+    exec cmd, {shell}, (code, stdout, stderr) ->
       try
         process.env = JSON.parse(stdout)
       catch e
@@ -214,8 +215,9 @@ class CommandOutputView extends View
     htmlStream.on 'data', (data) =>
       @cliOutput.append data
       @scrollToBottom()
+    shell = atom.config.get 'terminal-panel.shell'
     try
-      @program = exec inputCmd, stdio: 'pipe', env: process.env, cwd: @getCwd()
+      @program = exec inputCmd, stdio: 'pipe', env: process.env, cwd: @getCwd(), shell: shell
       @program.stdout.pipe htmlStream
       @program.stderr.pipe htmlStream
       removeClass @statusIcon, 'status-success'


### PR DESCRIPTION
Allows the user to configure the shell that will run the commands. The setting defaults to:
* Windows: `cmd.exe`
* other OS: `process.env.SHELL` or if it doesn't exist `/bin/bash`